### PR TITLE
#7 Add script to update grumphp.yml to add DDEV support.

### DIFF
--- a/scripts/update-grumphp-command.sh
+++ b/scripts/update-grumphp-command.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# Script to update the grumphp.yml file to use both Lando and DDEV on GIT commit.
+#
+# It's run on composer install, only if grumphp.yml exists and if it contains:
+# EXEC_GRUMPHP_COMMAND: lando php
+# This is the previous default we've used.
+#
+
+set -eu
+if [ -n "${WUNDERIO_DEBUG:-}" ]; then
+    set -x
+fi
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/var/www/html/vendor/bin
+
+# Path to the grumphp.yml file
+config_file="grumphp.yml"
+
+# Define the pattern to search for.
+pattern="EXEC_GRUMPHP_COMMAND: lando php"
+
+if [ -f "$config_file" ] && grep -q "$pattern" "$config_file"; then
+    sed -i "s#$pattern#EXEC_GRUMPHP_COMMAND: \"[ -d .ddev/traefik/ ] \&\& GRUMPHP_COMMAND='ddev php' || GRUMPHP_COMMAND='lando php' \&\& \$GRUMPHP_COMMAND\"#g" "$config_file"
+
+    # Add a message to the user.
+    color_red="\033[0;31m"
+    color_reset="\033[0m"
+    printf "${color_red}Added DDEV support to $config_file.\n"
+    echo "Please re-init GrumPHP GIT hooks and add $config_file to GIT:"
+    echo "ddev grumphp git:init"
+    echo "git add $config_file"
+    printf "${color_reset}"
+fi

--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -120,8 +120,9 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
 
     self::deployDdevFiles();
 
-    #$output = shell_exec('bash vendor/wunderio/lando-drupal/scripts/load_extensions.sh');
-    #$this->io->write("<info>{$output}</info>");
+    // Run the update-grumphp-command.php script.
+    $output = shell_exec('bash vendor/wunderio/ddev-drupal/scripts/update-grumphp-command.sh');
+    $this->io->write("<info>{$output}</info>");
   }
 
   /**


### PR DESCRIPTION
## Overview

Most of our project probably have Code Quality (GrumPHP) enabled and probably we have it set to run from Lando. If somebody decides to start using DDEV, then grumphp.yml should be updated to so that it then can decide if to run from DDEV or from Lando. It might not be a big deal that Lando starts temporarily, but ideally why should it, if we have DDEV working.

Current solutions logic:
1. We assume our projects can have both Lando and DDEV setups for now.
2. We assume developer uses either Lando or DDEV, but not both. So this means every developer has the project set up with either Lando or DDEV only.
3. So based on these assumptions, DDEV creates different folders under .ddev if it has been started. These are not there if you clone the project. So the trick is to check if .ddev/traefik/ folder exists and if so then start Code Quality with DDEV, if not then with Lando.

## Testing

1. Check that you have this in your grumphp.yml before the update:
![image](https://github.com/wunderio/ddev-drupal/assets/492375/724bfc43-4fd1-419f-a4e2-fc703ed17c2c)

2. Remove wunderio/ddev-drupal and install this branch:
```
ddev composer remove wunderio/ddev-drupal
ddev composer require wunderio/ddev-drupal:dev-feature/7-update-grumphp-git-hook-from-lando-to-ddev-aware --dev
```

3. You should see this:
![image](https://github.com/wunderio/ddev-drupal/assets/492375/518ee597-7c5b-44a4-badd-baac359d841b)

4. Act accordingly and try to commit something. Code Quality checks should happen in DDEV (you should not see Lando starting up).