### PR TITLE
#9 Create pmu tooling (drush pmu) wrapper initial script.

### DIFF
--- a/dist/.ddev/commands/web/wunderio-core-pmu.sh
+++ b/dist/.ddev/commands/web/wunderio-core-pmu.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+## Description: Runs drush pmu commands but also creates dummy module folder if it does not exist.
+## Usage: pmu
+## Example: "ddev pmu"
+
+/var/www/html/.ddev/wunderio/core/_run-scripts.sh tooling-pmu.sh "$@"

--- a/dist/.ddev/commands/web/wunderio-core-pmu.sh
+++ b/dist/.ddev/commands/web/wunderio-core-pmu.sh
@@ -2,6 +2,6 @@
 
 ## Description: Runs drush pmu commands but also creates dummy module folder if it does not exist.
 ## Usage: pmu
-## Example: "ddev pmu"
+## Example: "ddev pmu module1 module2 ..."
 
 /var/www/html/.ddev/wunderio/core/_run-scripts.sh tooling-pmu.sh "$@"

--- a/dist/.ddev/wunderio/core/tooling-pmu.sh
+++ b/dist/.ddev/wunderio/core/tooling-pmu.sh
@@ -32,7 +32,6 @@ disable_module() {
 
     # Create dummy module if the module directory doesn't exist.
     if [ $module_exists -eq 0 ]; then
-        echo "Creating directory for module $module_name..."
         mkdir -p "$module_path"
         touch "$module_path/$module_name.info.yml"
         echo "name: 'Dummy module created by ddev pmu'" > "$module_path/$module_name.info.yml"
@@ -49,7 +48,6 @@ disable_module() {
 
     # Remove dummy module if it was created.
     if [ $module_exists -eq 0 ]; then
-        echo "Removing directory for module $module_name..."
         rm -rf "$module_path"
     fi
 }

--- a/dist/.ddev/wunderio/core/tooling-pmu.sh
+++ b/dist/.ddev/wunderio/core/tooling-pmu.sh
@@ -26,7 +26,7 @@ if [ ! -d "web/modules/contrib/$module_name" ] && [ ! -d "web/modules/custom/$mo
     echo "Creating directory for module $module_name..."
     mkdir -p "web/modules/custom/$module_name"
 
-    # Create the .info.yml file inside the directory
+    # Create dummy module.
     touch "web/modules/custom/$module_name/$module_name.info.yml"
     echo "name: 'Dummy module created by ddev pmu'" >> "web/modules/custom/$module_name/$module_name.info.yml"
     echo "type: module" >> "web/modules/custom/$module_name/$module_name.info.yml"

--- a/dist/.ddev/wunderio/core/tooling-pmu.sh
+++ b/dist/.ddev/wunderio/core/tooling-pmu.sh
@@ -4,7 +4,7 @@
 # Helper script to run pmu, but also create temporary module directory if it doesn't exist.
 #
 
-set -eu
+set -u
 if [ -n "${WUNDERIO_DEBUG:-}" ]; then
     set -x
 fi

--- a/dist/.ddev/wunderio/core/tooling-pmu.sh
+++ b/dist/.ddev/wunderio/core/tooling-pmu.sh
@@ -33,9 +33,8 @@ disable_module() {
     # Create dummy module if the module directory doesn't exist.
     if [ $module_exists -eq 0 ]; then
         mkdir -p "$module_path"
-        touch "$module_path/$module_name.info.yml"
-        echo "name: 'Dummy module created by ddev pmu'" > "$module_path/$module_name.info.yml"
-        echo "type: module" >> "$module_path/$module_name.info.yml"
+        echo "name: 'Dummy module created by ddev pmu'"    > "$module_path/$module_name.info.yml"
+        echo "type: module"                               >> "$module_path/$module_name.info.yml"
         echo "core_version_requirement: ^9 || ^10 || ^11" >> "$module_path/$module_name.info.yml"
 
         # Clear caches to make the module available.

--- a/dist/.ddev/wunderio/core/tooling-pmu.sh
+++ b/dist/.ddev/wunderio/core/tooling-pmu.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+#
+# Helper script to run pmu, but also create temporary module directory if it doesn't exist.
+#
+
+set -eu
+if [ -n "${WUNDERIO_DEBUG:-}" ]; then
+    set -x
+fi
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/var/www/html/vendor/bin
+
+# Define the module machine name passed as an argument
+module_name="$1"
+
+if [ -z "$module_name" ]; then
+    echo "Please provide the module machine name as an argument."
+    exit 0
+fi
+
+cd /var/www/html
+
+# Check if the module directory exists.
+if [ ! -d "web/modules/contrib/$module_name" ] && [ ! -d "web/modules/custom/$module_name" ] && [ ! -d "web/core/modules/$module_name" ]; then
+    # If the directory doesn't exist, create it
+    echo "Creating directory for module $module_name..."
+    mkdir -p "web/modules/custom/$module_name"
+
+    # Create the .info.yml file inside the directory
+    touch "web/modules/custom/$module_name/$module_name.info.yml"
+    echo "name: 'Dummy module created by ddev pmu'" >> "web/modules/custom/$module_name/$module_name.info.yml"
+    echo "type: module" >> "web/modules/custom/$module_name/$module_name.info.yml"
+    echo "core_version_requirement: ^9 || ^10 || ^11" >> "web/modules/custom/$module_name/$module_name.info.yml"
+
+    # Run "drush pmu" command.
+    echo "Disabling module $module_name..."
+    drush cr
+    drush pmu -y "$module_name"
+
+    # Remove the temporary directory.
+    echo "Removing directory for module $module_name..."
+    rm -rf "web/modules/custom/$module_name"
+else
+    # Run "drush pmu" command.
+    echo "Disabling module $module_name..."
+    drush pmu -y "$module_name"
+fi


### PR DESCRIPTION
## Overview

During development there are cases when you are in a state where module code is gone, but db still requires it to continue. To fix it, you'll have to either put the module back or in my case I've created dummy small module (info file) and then run pmu. This PR is about autoamating the dummy module creation if needed.

Current solutions logic:
1. The command is `ddev pmu module_name` because we are used to pmu (I think? Maybe some use the longer version?)
2. It looks for the module_name from contrib, custom and core module folders.
3. If it doesn't find it, then it'll create dummy module under custom and clear caches
4. It then proceeds to run `drush pmu`
5. After it's done, it removes the dummy module.
6. If in step 2 it finds module, then it skips creating dummy module and just run `drush pmu`

## Testing
Install the version from current branch:

1.
```
ddev composer require wunderio/ddev-drupal:dev-feature/9-Create-wrapper-for-pmu-to-be-able-to-uninstall-modules-that-dont-exist-in-code --dev
```

2. Remove some module from your code.

3. Try to uninstall the module with drush `ddev drush pmu your_module`. It should yell about missing module and it can't proceed.
![image](https://github.com/wunderio/ddev-drupal/assets/492375/842863dc-d356-4c5e-9c25-552a560e26c4)


5. Remove the module with new command `ddev pmu your_module`.