### PR TITLE
#17 In "ddev pmu" command always do cr before drush pmu

### DIFF
--- a/dist/.ddev/wunderio/core/tooling-pmu.sh
+++ b/dist/.ddev/wunderio/core/tooling-pmu.sh
@@ -36,10 +36,10 @@ disable_module() {
         echo "name: 'Dummy module created by ddev pmu'"    > "$module_path/$module_name.info.yml"
         echo "type: module"                               >> "$module_path/$module_name.info.yml"
         echo "core_version_requirement: ^9 || ^10 || ^11" >> "$module_path/$module_name.info.yml"
-
-        # Clear caches to make the module available.
-        drush cr
     fi
+
+    # Clear caches to make the module available.
+    drush cr
 
     # Run "drush pmu" command.
     echo "Disabling module $module_name..."


### PR DESCRIPTION
## Overview

`ddev pmu` was created to uninstall module if module does not exist anymore and none of Drush command work anymore as it's trying to find the files.

This PR changes `ddev pmu` command a bit (not to be mistaken with `ddev drush pmu`) to always do clear cache before it runs `drush pmu`. 

## Testing

I couldn't really repeat the issue, but at some point my Drupal was in a linbo that `ddev pmu` could not create the module because it existed so it never ran the clear cache and pmu failed. But I think doing clear cache just in case running drush pmu does make sense and make it more bullet-proof.