### PR TITLE
#6 Run post db updates after snapshot restore.

### DIFF
--- a/dist/.ddev/config.wunderio.yaml
+++ b/dist/.ddev/config.wunderio.yaml
@@ -1,6 +1,8 @@
 hooks:
   post-import-db:
     - exec: "/var/www/html/.ddev/wunderio/core/_run-scripts.sh hooks-db-post-import.sh"
+  post-restore-snapshot:
+    - exec: "/var/www/html/.ddev/wunderio/core/_run-scripts.sh hooks-db-post-import.sh"
   post-start:
     # Build hook workaround to run composer install on first start.
     # @todo We could potentially make this more like lando build hook by creating tmp files.


### PR DESCRIPTION
## Overview

Database snapshots like database dumps are probably at least a little-bit behind the codebase so let's run the same post db import script as we do after db import (in current PR 1 line above the change). Atm this will clear caches, sanitize db and generate uli link - https://github.com/wunderio/ddev-drupal/blob/main/dist/.ddev/wunderio/core/hooks-db-post-import.sh . In future maybe we'll also add `drush deploy`.

## Screenshots

![image](https://github.com/wunderio/ddev-drupal/assets/492375/e0ed1757-ec2f-4c9c-8998-55d0338b8452)


## Testing

1. Install this update to your site:
`ddev composer require wunderio/ddev-drupal:dev-feature/6-Run-post-db-updates-after-snapshot-restore --dev`
Note that switching to feature branch confuses our auto update command so after restoring snapshot in next step, don't say **y**
![image](https://github.com/wunderio/ddev-drupal/assets/492375/c6d4a596-cc21-4b7f-9946-b9f44d337d45)

3. Create snapshot if you don't already have one.
`ddev snapshot --name testing-post-restore-snapshot`

4. Restore the snapshot which will trigger the hook:
`ddev snapshot restore testing-post-restore-snapshot`

5. Finally delete the snapshot (using wildcard because ending is your db engine which can vary).
`rm -rf .ddev/db_snapshots/testing-post-restore-snapshot*`
