### PR TITLE
#32 Allow Drupal 11 in Composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "drupal/core": "^8 || ^9 || ^10",
+        "drupal/core": "^8 || ^9 || ^10 || ^11",
         "composer-plugin-api": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Overview

Allow installing Drupal 11.

## Testing

- ddev composer require wunderio/ddev-drupal --dev && ddev restart
- Require Drupal 11