### PR TITLE
#34 Optimize database dumps handling on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,19 @@ URL will become example.com.ddev.site.
    ```bash
    ddev drush uli
    ```
+
+## Performance Optimization
+
+### Database Operations (Mac-specific)
+
+For better performance with database operations on macOS, the `database_dumps` directory
+is configured to be bind-mounted directly rather than synced via Mutagen. This is done
+through the `upload_dirs` configuration in `.ddev/config.wunderio.yaml`:
+
+```yaml
+upload_dirs:
+  - ../database_dumps
+```
+
+This improves performance when importing/exporting large databases by bypassing
+Mutagen's syncing mechanism, which is only used on macOS.

--- a/dist/.ddev/config.wunderio.yaml
+++ b/dist/.ddev/config.wunderio.yaml
@@ -18,3 +18,12 @@ web_environment:
 # at drush/sites/local.site.yml. To make sure that the local alias
 # is working, we need to set the same environment variables here.
 - LANDO_WEBROOT=$DDEV_COMPOSER_ROOT/$DDEV_DOCROOT
+# When Mutagen is enabled (which it is by default in DDEV v1.19+),
+# these directories are bind-mounted directly rather than synced via Mutagen
+# This improves performance for large file directories by bypassing Mutagen's
+# syncing.
+# The paths are relative to the project root.
+upload_dirs:
+  # Configure database_dumps directory to be bind-mounted directly
+  # instead of being synced via Mutagen for better performance
+  - ../database_dumps


### PR DESCRIPTION
## Overview

This pull request includes a new performance optimization for database dumps on macOS. 

## Screenshots

![Screenshot 2025-04-14 at 08 16 03](https://github.com/user-attachments/assets/02e379b9-a569-4942-bbfe-90a35ef0e6ef)


## Testing

Try out dev version

```
ddev composer require wunderio/ddev-drupal:dev-feature/34-Bind-Mount-Database-Dumps-Directory --dev
```

database_dumps folder should appear in your project. Move your db dumps there.

Check teh size of virtual disk and also time it starts DDEV with and without the change.