### PR TITLE
Feature/43 quickly enable twig debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ scripts to enhance your Drupal development workflow.
   ```bash
   ddev pmu module1 module2 ...
   ```
+- `twig-debug`: Toggles Drupal Twig debugging on/off. Useful for template development.
+  ```bash
+  ddev twig-debug        # Enable Twig debugging
+  ddev twig-debug off    # Disable Twig debugging
+  ```
 - `grumphp`: Runs GrumPHP commands
   ```bash
   ddev grumphp

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "drupal/core": "^8 || ^9 || ^10 || ^11",
+        "drupal/core": "^10.3 || ^11",
         "composer-plugin-api": "^2.0"
     },
     "require-dev": {

--- a/dist/.ddev/commands/web/wunderio-core-twig-debug.sh
+++ b/dist/.ddev/commands/web/wunderio-core-twig-debug.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+## Description: Toggle Drupal Twig debugging.
+## Usage: twig-debug [off]
+## Example: "ddev twig-debug" to enable or "ddev twig-debug off" to disable
+
+# Function to check if twig debugging is enabled.
+is_enabled() {
+  if [ "$(drush php:eval "echo \Drupal::keyValue('development_settings')->get('twig_debug') ? 'true' : 'false';")" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Function to enable Twig debugging.
+enable_twig_debug() {
+  drush php:eval "\Drupal::keyValue('development_settings')->setMultiple(['disable_rendered_output_cache_bins' => TRUE, 'twig_debug' => TRUE, 'twig_cache_disable' => TRUE]);"
+  echo "Enabled twig-debug"
+  drush cr >/dev/null 2>&1
+}
+
+# Function to disable Twig debugging.
+disable_twig_debug() {
+  drush php:eval "\Drupal::keyValue('development_settings')->setMultiple(['disable_rendered_output_cache_bins' => FALSE, 'twig_debug' => FALSE, 'twig_cache_disable' => FALSE]);"
+  echo "Disabled twig-debug"
+  drush cr >/dev/null 2>&1
+}
+
+# Handle command parameters.
+if [ "$1" = "off" ]; then
+  disable_twig_debug
+else
+  if is_enabled; then
+    echo "Twig debugging is already enabled"
+  else
+    enable_twig_debug
+  fi
+fi


### PR DESCRIPTION
## Overview

Adding a new utility for toggling Twig debugging and updating the Drupal core version requirements in `composer.json` related to that.

### Workflow Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R21): Added a new utility, `twig-debug`, to toggle Drupal Twig debugging on or off, aiding template development.

### Dependency Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L16-R16): Updated the `drupal/core` version requirement to `^10.3 || ^11`, removing support for older versions.

## Testing



