### PR TITLE
#50 Automatically also add drush/sites/local.site.yml to git when updating

### DIFF
--- a/scripts/update_check.sh
+++ b/scripts/update_check.sh
@@ -73,13 +73,13 @@ if [[ $answer == "yes" ]] || [[ $answer == "y" ]]; then
     composer require wunderio/ddev-drupal --dev
     echo ""
     display_status_message "Staging the changes to GIT. "
-    read -rp "$(display_status_message "wunderio/ddev-drupal is updated, let's now add changes to GIT. This will run 'git add .ddev/ composer.json composer.lock' (yes/no): [y] ")" answer2
+    read -rp "$(display_status_message "wunderio/ddev-drupal is updated, let's now add changes to GIT. This will run 'git add .ddev/ composer.json composer.lock drush/sites/local.site.yml' (yes/no): [y] ")" answer2
     # Convert the input to lowercase for case-insensitive comparison.
     answer2=${answer2,,}
     # If the answer is empty (user pressed Enter), default to "y".
     answer2=${answer2:-y}
     if [[ $answer2 == "yes" ]] || [[ $answer2 == "y" ]]; then
-        git add .ddev/ composer.json composer.lock
+        git add .ddev/ composer.json composer.lock drush/sites/local.site.yml
         display_status_message "Done! Please verify the staged changes and commit (git status / git commit)."
     else
         display_status_message "Skipping the GIT staging. You need to manually stage the changes to GIT."


### PR DESCRIPTION
## Overview

This pull request makes a minor update to the `scripts/update_check.sh` script, improving the Git staging process by including an additional file.

* The prompt and `git add` command now include `drush/sites/local.site.yml` along with the previously staged files, ensuring this important configuration file is added to version control when updating `wunderio/ddev-drupal`.

## Screenshots

<img width="1069" height="456" alt="Screenshot 2025-10-31 at 17 17 58" src="https://github.com/user-attachments/assets/4600ede7-73b1-491c-b1b8-793b4520ffa6" />

## Testing

I don't know really how to test this easily so I'd just do eyescan and let's commit this.



