### PR TITLE
Only deploy configs on local environment 

### DIFF
--- a/src/InstallHelperPlugin.php
+++ b/src/InstallHelperPlugin.php
@@ -101,6 +101,11 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
    *   Composer package event sent on install/update/remove.
    */
   public function onWunderIoDdevDrupalPackageInstall(PackageEvent $event) {
+    // Unless its DDEV enviroment we dont have nothing to do here.
+    if (!getenv('IS_DDEV_PROJECT')) {
+        return;
+    }
+
     /** @var \Composer\DependencyResolver\Operation\InstallOperation $operation */
     $operation = $event->getOperation();
 
@@ -116,11 +121,6 @@ class InstallHelperPlugin implements PluginInterface, EventSubscriberInterface {
     // We only want to continue for this package.
     if ($current_package_name !== self::PACKAGE_NAME) {
       return NULL;
-    }
-
-    // Nothing to do here anymore.
-    if (!getenv('IS_DDEV_PROJECT')) {
-        return;
     }
 
     self::deployDdevFiles();


### PR DESCRIPTION
## Overview

- When using silta default validate job it tries to install dev dependencies too which leads this plugin to fail copy files over. Added enviroment check for the DDEV so that we dont try to do not needed stuff out of context

## Testing

Make sure composer plugin doesnt install ddev files unless it is in correct context

